### PR TITLE
Add ability to specify the bowerDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ MainFilePicker.prototype.write = function (readTree, destDir) {
 
 
 module.exports = findBowerTrees
-function findBowerTrees () {
-  var bowerDir = require('bower-config').read().directory // note: this relies on cwd
+function findBowerTrees (bowerDir) {
+  var bowerDir = bowerDir || require('bower-config').read().directory // note: this relies on cwd
   if (bowerDir == null) throw new Error('Bower did not return a directory')
   var entries = fs.readdirSync(bowerDir)
   var directories = entries.filter(function (f) {


### PR DESCRIPTION
This is useful when the bower.json isn't in a sensible location.
